### PR TITLE
Fix timecode conversion

### DIFF
--- a/blackhole/database_utils.py
+++ b/blackhole/database_utils.py
@@ -35,7 +35,8 @@ def getSystemTimecodeAsFrames(frameRate : int):
     """
     systemTime = datetime.now()
 
-    systemTimeSeconds = (systemTime.hour * 60 + systemTime.minute) * 60 + systemTime.second + systemTime.microsecond
+    systemTimeSeconds = ((systemTime.hour * 60 + systemTime.minute) * 60 + systemTime.second
+                           + (systemTime.microsecond / 1000000))
 
     timecode = Timecode(frameRate, start_seconds=systemTimeSeconds)
     return timecode.frames


### PR DESCRIPTION
Cherrypicked fix from #3 to fix timecode conversion

Timecode was not being correctly converted to frames due to not converting datetime.now().microseconds to seconds.